### PR TITLE
Fix correct Maven ArtifactId in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-validation-resources-R4</artifactId>
+			<artifactId>hapi-fhir-validation-resources-r4</artifactId>
 			<version>4.2.0</version>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
BEFORE:

![image](https://user-images.githubusercontent.com/1699252/94338809-713b3f00-fff5-11ea-914d-6126d2dce570.png)

AFTER:

![image](https://user-images.githubusercontent.com/1699252/94338822-89ab5980-fff5-11ea-8b5e-fc2408dc3e84.png)
