### PR TITLE
GitHub Action: Build with Maven check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Maven Build
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8      
+    - name: Build with Maven
+      run: mvn -B clean verify --fae --file pom.xml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Maven Build status](https://github.com/RedHat-Healthcare/iDAAS-EventBuilder/workflows/Maven%20Build/badge.svg)
+
 # iDAAS-EventBuilder
 iDAAS EventBuilder is designed to help ANY implementation build, parse and/or transform data.
 


### PR DESCRIPTION
To mitigate/avoid unreproducible builds as reported in https://github.com/RedHat-Healthcare/iDAAS-EventBuilder/pull/2,
we could start to integrate some CI checks.

This PR contributes a first iteration of GitHub Action to perform a standard Build with Maven on Pull Request submission, and every time a new commit is added to the branches (on say, merge on the default branch).

Additionally, a status badge is added to the root README file.